### PR TITLE
[codex] Add project archiving and restore flow

### DIFF
--- a/app/projects/[projectId]/page.tsx
+++ b/app/projects/[projectId]/page.tsx
@@ -2,12 +2,15 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import type { Route } from "next";
 import { PageContainer } from "@/components/layout/page-container";
+import { Button } from "@/components/ui/button";
 import { requireCurrentUser } from "@/server/auth/session";
 import { listProjectChangeOrdersForUser } from "@/features/change-orders/queries/list-project-change-orders";
 import { listProjectDecisionsForUser } from "@/features/decisions/queries/list-project-decisions";
+import { archiveProjectAction } from "@/features/projects/actions/archive-project";
 import { getProjectForUser } from "@/features/projects/queries/get-project";
 import { getProjectIntakeForUser } from "@/features/intake/queries/get-project-intake";
 import { listProjectActivityForUser } from "@/features/projects/queries/list-project-activity";
+import { restoreProjectAction } from "@/features/projects/actions/restore-project";
 
 function formatLabel(value: string) {
   return value.replaceAll("_", " ");
@@ -57,6 +60,10 @@ export default async function ProjectWorkspacePage({
   if (!project || !changeOrders) {
     notFound();
   }
+
+  const lifecycleAction = project.archivedAt
+    ? restoreProjectAction.bind(null, project.id)
+    : archiveProjectAction.bind(null, project.id);
 
   const intakeCompleted = Boolean(intakeRecord?.intake?.completedAt);
   const intakeStarted = Boolean(intakeRecord?.intake);
@@ -130,30 +137,53 @@ export default async function ProjectWorkspacePage({
               {project.title}
             </h2>
             <p className="text-muted mt-3 max-w-2xl text-sm leading-7">
-              The project shell is active. Continue with intake to capture the
-              room list, goals, budget range, timing, and constraints that will
-              drive the first scope draft.
+              {project.archivedAt
+                ? "This project is archived. It stays intact, but it is hidden from the active project list until restored."
+                : "The project shell is active. Continue with intake to capture the room list, goals, budget range, timing, and constraints that will drive the first scope draft."}
             </p>
           </div>
-          <div className="grid gap-3 sm:grid-cols-2 lg:w-[360px]">
-            <div className="bg-surface-strong/55 rounded-[1.5rem] px-4 py-4">
-              <p className="text-muted text-xs uppercase tracking-[0.2em]">
-                Status
-              </p>
-              <p className="mt-2 text-base font-semibold capitalize">
-                {formatLabel(project.status)}
-              </p>
-            </div>
-            <div className="bg-surface-strong/55 rounded-[1.5rem] px-4 py-4">
-              <p className="text-muted text-xs uppercase tracking-[0.2em]">
-                Type
-              </p>
-              <p className="mt-2 text-base font-semibold capitalize">
-                {formatLabel(project.projectType)}
-              </p>
+          <div className="flex flex-col gap-3 lg:items-end">
+            <form action={lifecycleAction}>
+              <Button
+                type="submit"
+                variant={project.archivedAt ? "default" : "outline"}
+                className="rounded-full px-5"
+              >
+                {project.archivedAt ? "Restore project" : "Archive project"}
+              </Button>
+            </form>
+            <div className="grid gap-3 sm:grid-cols-2 lg:w-[360px]">
+              <div className="bg-surface-strong/55 rounded-[1.5rem] px-4 py-4">
+                <p className="text-muted text-xs uppercase tracking-[0.2em]">
+                  Status
+                </p>
+                <p className="mt-2 text-base font-semibold capitalize">
+                  {formatLabel(project.status)}
+                </p>
+              </div>
+              <div className="bg-surface-strong/55 rounded-[1.5rem] px-4 py-4">
+                <p className="text-muted text-xs uppercase tracking-[0.2em]">
+                  Type
+                </p>
+                <p className="mt-2 text-base font-semibold capitalize">
+                  {formatLabel(project.projectType)}
+                </p>
+              </div>
             </div>
           </div>
         </div>
+
+        {project.archivedAt ? (
+          <div className="mt-6 rounded-[1.5rem] border border-stone-300 bg-stone-50 px-5 py-4">
+            <p className="text-muted text-xs uppercase tracking-[0.2em]">
+              Archived
+            </p>
+            <p className="mt-2 text-sm leading-7">
+              Archived on {project.archivedAt.toLocaleDateString()}. Restore the
+              project when it needs to return to the active workspace list.
+            </p>
+          </div>
+        ) : null}
 
         <div className="mt-8 grid gap-4 lg:grid-cols-2">
           <div className="border-border rounded-[1.5rem] border px-5 py-5">

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { AppShell } from "@/components/layout/app-shell";
 import { Button } from "@/components/ui/button";
 import { requireCurrentUser } from "@/server/auth/session";
+import { restoreProjectAction } from "@/features/projects/actions/restore-project";
 import { listProjectsForUser } from "@/features/projects/queries/list-projects";
 
 function formatProjectType(value: string) {
@@ -12,9 +13,76 @@ function formatStatus(value: string) {
   return value.replaceAll("_", " ");
 }
 
-export default async function ProjectsPage() {
+function formatDate(value: Date) {
+  return value.toLocaleDateString();
+}
+
+type ProjectListView = "active" | "archived";
+
+type ProjectsPageProps = {
+  searchParams?: Promise<{
+    view?: string;
+  }>;
+};
+
+type ProjectCardProps = {
+  project: Awaited<ReturnType<typeof listProjectsForUser>>[number];
+  view: ProjectListView;
+};
+
+function ProjectCard({ project, view }: ProjectCardProps) {
+  const restoreProject = restoreProjectAction.bind(null, project.id);
+
+  return (
+    <article className="border-border bg-surface rounded-[1.75rem] border px-5 py-5 shadow-[0_16px_40px_rgba(54,42,20,0.05)]">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="bg-accent-soft text-foreground rounded-full px-3 py-1 text-xs font-medium capitalize">
+          {view === "archived" ? "Archived" : formatStatus(project.status)}
+        </span>
+        <span className="text-muted text-xs capitalize">
+          {formatProjectType(project.projectType)}
+        </span>
+      </div>
+
+      <h3 className="mt-4 text-xl font-semibold">{project.title}</h3>
+      <p className="text-muted mt-2 text-sm leading-6">
+        {project.locationLabel ?? "Location not set yet"}
+      </p>
+      <p className="text-muted mt-4 text-xs">
+        {view === "archived" && project.archivedAt
+          ? `Archived ${formatDate(project.archivedAt)}`
+          : `Updated ${formatDate(project.updatedAt)}`}
+      </p>
+
+      <div className="mt-5 flex flex-wrap gap-3">
+        <Button asChild variant="outline" className="rounded-full px-4">
+          <Link href={`/projects/${project.id}`}>Open project</Link>
+        </Button>
+        {view === "archived" ? (
+          <form action={restoreProject}>
+            <Button type="submit" className="rounded-full px-4">
+              Restore
+            </Button>
+          </form>
+        ) : null}
+      </div>
+    </article>
+  );
+}
+
+export default async function ProjectsPage({ searchParams }: ProjectsPageProps) {
   const user = await requireCurrentUser();
-  const projects = await listProjectsForUser(user.id);
+  const resolvedSearchParams = searchParams ? await searchParams : undefined;
+  const currentView: ProjectListView =
+    resolvedSearchParams?.view === "archived" ? "archived" : "active";
+  const [activeProjects, archivedProjects] = await Promise.all([
+    listProjectsForUser(user.id, { archived: false }),
+    listProjectsForUser(user.id, { archived: true }),
+  ]);
+
+  const projects =
+    currentView === "archived" ? archivedProjects : activeProjects;
+  const isArchivedView = currentView === "archived";
 
   return (
     <AppShell>
@@ -29,47 +97,55 @@ export default async function ProjectsPage() {
                 Project workspace index
               </h2>
               <p className="text-muted mt-3 max-w-2xl text-sm leading-7">
-                Start a new renovation project or reopen an active one.
+                {isArchivedView
+                  ? "Review archived projects and restore them when they need to return to active work."
+                  : "Start a new renovation project or reopen an active one."}
               </p>
             </div>
             <Button asChild className="rounded-full px-5">
               <Link href="/projects/new">Create project</Link>
             </Button>
           </div>
+
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Button
+              asChild
+              variant={isArchivedView ? "outline" : "default"}
+              className="rounded-full px-4"
+            >
+              <Link href="/projects">Active projects</Link>
+            </Button>
+            <Button
+              asChild
+              variant={isArchivedView ? "default" : "outline"}
+              className="rounded-full px-4"
+            >
+              <Link href="/projects?view=archived">Archived projects</Link>
+            </Button>
+          </div>
         </div>
 
         {projects.length === 0 ? (
           <div className="border-border bg-surface rounded-[2rem] border px-6 py-8 shadow-[0_18px_60px_rgba(54,42,20,0.08)]">
-            <h3 className="text-xl font-semibold">No projects yet</h3>
+            <h3 className="text-xl font-semibold">
+              {isArchivedView ? "No archived projects" : "No active projects"}
+            </h3>
             <p className="text-muted mt-3 max-w-2xl text-sm leading-7">
-              Create the first project shell, then move into guided intake and
-              scope drafting.
+              {isArchivedView
+                ? "Archived projects stay available here until they are restored."
+                : archivedProjects.length > 0
+                  ? "Active projects are empty right now. Archived work is still available in the archived view."
+                  : "Create the first project shell, then move into guided intake and scope drafting."}
             </p>
           </div>
         ) : (
           <div className="grid gap-4 xl:grid-cols-2">
             {projects.map((project) => (
-              <Link
+              <ProjectCard
                 key={project.id}
-                href={`/projects/${project.id}`}
-                className="border-border bg-surface hover:border-accent block rounded-[1.75rem] border px-5 py-5 shadow-[0_16px_40px_rgba(54,42,20,0.05)] transition"
-              >
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="bg-accent-soft text-foreground rounded-full px-3 py-1 text-xs font-medium capitalize">
-                    {formatStatus(project.status)}
-                  </span>
-                  <span className="text-muted text-xs capitalize">
-                    {formatProjectType(project.projectType)}
-                  </span>
-                </div>
-                <h3 className="mt-4 text-xl font-semibold">{project.title}</h3>
-                <p className="text-muted mt-2 text-sm leading-6">
-                  {project.locationLabel ?? "Location not set yet"}
-                </p>
-                <p className="text-muted mt-4 text-xs">
-                  Updated {project.updatedAt.toLocaleDateString()}
-                </p>
-              </Link>
+                project={project}
+                view={currentView}
+              />
             ))}
           </div>
         )}

--- a/db/migrations/20260401193000_project_archiving_activity/migration.sql
+++ b/db/migrations/20260401193000_project_archiving_activity/migration.sql
@@ -1,0 +1,2 @@
+ALTER TYPE "ActivityEventType" ADD VALUE IF NOT EXISTS 'project_archived';
+ALTER TYPE "ActivityEventType" ADD VALUE IF NOT EXISTS 'project_restored';

--- a/db/schema/schema.prisma
+++ b/db/schema/schema.prisma
@@ -40,6 +40,8 @@ enum ContractorInvolvement {
 
 enum ActivityEventType {
   project_created
+  project_archived
+  project_restored
   project_updated
   intake_started
   intake_saved

--- a/features/projects/actions/archive-project.ts
+++ b/features/projects/actions/archive-project.ts
@@ -1,0 +1,69 @@
+"use server";
+
+import { ActivityEventType } from "@prisma/client";
+import { revalidatePath } from "next/cache";
+import { db } from "@/server/db/client";
+import { requireCurrentUser } from "@/server/auth/session";
+import { getProjectForUser } from "@/features/projects/queries/get-project";
+
+type ArchiveProjectActionDependencies = {
+  db: typeof db;
+  requireCurrentUser: typeof requireCurrentUser;
+  getProjectForUser: typeof getProjectForUser;
+  revalidatePath: typeof revalidatePath;
+};
+
+const archiveProjectActionDependencies: ArchiveProjectActionDependencies = {
+  db,
+  requireCurrentUser,
+  getProjectForUser,
+  revalidatePath,
+};
+
+export async function archiveProjectAction(projectId: string) {
+  return archiveProjectActionWithDependencies(
+    archiveProjectActionDependencies,
+    projectId,
+  );
+}
+
+export async function archiveProjectActionWithDependencies(
+  dependencies: ArchiveProjectActionDependencies,
+  projectId: string,
+) {
+  const user = await dependencies.requireCurrentUser();
+  const project = await dependencies.getProjectForUser(projectId, user.id);
+
+  if (!project || project.archivedAt) {
+    return;
+  }
+
+  const archivedAt = new Date();
+
+  await dependencies.db.$transaction(async (tx) => {
+    await tx.project.update({
+      where: {
+        id: projectId,
+      },
+      data: {
+        archivedAt,
+      },
+    });
+
+    await tx.activityLog.create({
+      data: {
+        projectId,
+        workspaceId: project.workspaceId,
+        actorId: user.id,
+        eventType: ActivityEventType.project_archived,
+        summary: `Archived project ${project.title}.`,
+        metadata: {
+          archivedAt: archivedAt.toISOString(),
+        },
+      },
+    });
+  });
+
+  dependencies.revalidatePath("/projects");
+  dependencies.revalidatePath(`/projects/${projectId}`);
+}

--- a/features/projects/actions/restore-project.ts
+++ b/features/projects/actions/restore-project.ts
@@ -1,0 +1,69 @@
+"use server";
+
+import { ActivityEventType } from "@prisma/client";
+import { revalidatePath } from "next/cache";
+import { db } from "@/server/db/client";
+import { requireCurrentUser } from "@/server/auth/session";
+import { getProjectForUser } from "@/features/projects/queries/get-project";
+
+type RestoreProjectActionDependencies = {
+  db: typeof db;
+  requireCurrentUser: typeof requireCurrentUser;
+  getProjectForUser: typeof getProjectForUser;
+  revalidatePath: typeof revalidatePath;
+};
+
+const restoreProjectActionDependencies: RestoreProjectActionDependencies = {
+  db,
+  requireCurrentUser,
+  getProjectForUser,
+  revalidatePath,
+};
+
+export async function restoreProjectAction(projectId: string) {
+  return restoreProjectActionWithDependencies(
+    restoreProjectActionDependencies,
+    projectId,
+  );
+}
+
+export async function restoreProjectActionWithDependencies(
+  dependencies: RestoreProjectActionDependencies,
+  projectId: string,
+) {
+  const user = await dependencies.requireCurrentUser();
+  const project = await dependencies.getProjectForUser(projectId, user.id);
+
+  if (!project || !project.archivedAt) {
+    return;
+  }
+
+  const archivedAt = project.archivedAt;
+
+  await dependencies.db.$transaction(async (tx) => {
+    await tx.project.update({
+      where: {
+        id: projectId,
+      },
+      data: {
+        archivedAt: null,
+      },
+    });
+
+    await tx.activityLog.create({
+      data: {
+        projectId,
+        workspaceId: project.workspaceId,
+        actorId: user.id,
+        eventType: ActivityEventType.project_restored,
+        summary: `Restored project ${project.title}.`,
+        metadata: {
+          restoredFromArchivedAt: archivedAt.toISOString(),
+        },
+      },
+    });
+  });
+
+  dependencies.revalidatePath("/projects");
+  dependencies.revalidatePath(`/projects/${projectId}`);
+}

--- a/features/projects/queries/get-project.ts
+++ b/features/projects/queries/get-project.ts
@@ -25,6 +25,7 @@ export const getProjectForUser = cache(
         locationLabel: true,
         goals: true,
         status: true,
+        archivedAt: true,
         createdAt: true,
         updatedAt: true,
       },

--- a/features/projects/queries/list-projects.ts
+++ b/features/projects/queries/list-projects.ts
@@ -2,30 +2,36 @@ import { cache } from "react";
 import { db } from "@/server/db/client";
 import { listUserWorkspaceIds } from "@/server/permissions/workspace";
 
-export const listProjectsForUser = cache(async (userId: string) => {
-  const workspaceIds = await listUserWorkspaceIds(userId);
+type ListProjectsForUserOptions = {
+  archived?: boolean;
+};
 
-  if (workspaceIds.length === 0) {
-    return [];
-  }
+export const listProjectsForUser = cache(
+  async (userId: string, options: ListProjectsForUserOptions = {}) => {
+    const workspaceIds = await listUserWorkspaceIds(userId);
+    const archived = options.archived ?? false;
 
-  return db.project.findMany({
-    where: {
-      workspaceId: {
-        in: workspaceIds,
+    if (workspaceIds.length === 0) {
+      return [];
+    }
+
+    return db.project.findMany({
+      where: {
+        workspaceId: {
+          in: workspaceIds,
+        },
+        archivedAt: archived ? { not: null } : null,
       },
-      archivedAt: null,
-    },
-    orderBy: {
-      updatedAt: "desc",
-    },
-    select: {
-      id: true,
-      title: true,
-      projectType: true,
-      status: true,
-      locationLabel: true,
-      updatedAt: true,
-    },
-  });
-});
+      orderBy: archived ? { archivedAt: "desc" } : { updatedAt: "desc" },
+      select: {
+        id: true,
+        title: true,
+        projectType: true,
+        status: true,
+        locationLabel: true,
+        archivedAt: true,
+        updatedAt: true,
+      },
+    });
+  },
+);

--- a/tests/projects/project-archiving.test.ts
+++ b/tests/projects/project-archiving.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { archiveProjectActionWithDependencies } from "@/features/projects/actions/archive-project";
+import { restoreProjectActionWithDependencies } from "@/features/projects/actions/restore-project";
+import { getProjectForUser } from "@/features/projects/queries/get-project";
+import { listProjectsForUser } from "@/features/projects/queries/list-projects";
+import { db } from "@/server/db/client";
+import { createIntegrationContext } from "@/tests/support/db";
+import { createNavigationHarness } from "@/tests/support/navigation";
+
+test("archiveProjectAction archives the project, hides it from the active list, and logs activity", async (t) => {
+  const integration = createIntegrationContext();
+  t.after(async () => {
+    await integration.cleanup();
+  });
+
+  const owner = await integration.createWorkspaceMember();
+  const project = await integration.createProject({
+    workspaceId: owner.workspace.id,
+    createdById: owner.user.id,
+    title: "Back Addition",
+  });
+  const navigation = createNavigationHarness();
+
+  await archiveProjectActionWithDependencies(
+    {
+      db,
+      requireCurrentUser: async () => owner.user,
+      getProjectForUser,
+      revalidatePath: navigation.revalidatePath,
+    },
+    project.id,
+  );
+
+  assert.deepEqual(navigation.revalidatedPaths, [
+    "/projects",
+    `/projects/${project.id}`,
+  ]);
+
+  const archivedProject = await getProjectForUser(project.id, owner.user.id);
+  assert.ok(archivedProject?.archivedAt instanceof Date);
+
+  const activeProjects = await listProjectsForUser(owner.user.id, {
+    archived: false,
+  });
+  const archivedProjects = await listProjectsForUser(owner.user.id, {
+    archived: true,
+  });
+
+  assert.equal(activeProjects.length, 0);
+  assert.equal(archivedProjects.length, 1);
+  assert.equal(archivedProjects[0]?.id, project.id);
+  assert.ok(archivedProjects[0]?.archivedAt instanceof Date);
+
+  const activity = await db.activityLog.findMany({
+    where: {
+      projectId: project.id,
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+    select: {
+      eventType: true,
+      summary: true,
+    },
+  });
+
+  assert.equal(activity[0]?.eventType, "project_archived");
+  assert.equal(activity[0]?.summary, "Archived project Back Addition.");
+});
+
+test("restoreProjectAction restores an archived project and logs activity", async (t) => {
+  const integration = createIntegrationContext();
+  t.after(async () => {
+    await integration.cleanup();
+  });
+
+  const owner = await integration.createWorkspaceMember();
+  const project = await integration.createProject({
+    workspaceId: owner.workspace.id,
+    createdById: owner.user.id,
+    title: "Garden Suite",
+  });
+
+  await db.project.update({
+    where: {
+      id: project.id,
+    },
+    data: {
+      archivedAt: new Date("2026-03-15T10:00:00.000Z"),
+    },
+  });
+
+  const navigation = createNavigationHarness();
+
+  await restoreProjectActionWithDependencies(
+    {
+      db,
+      requireCurrentUser: async () => owner.user,
+      getProjectForUser,
+      revalidatePath: navigation.revalidatePath,
+    },
+    project.id,
+  );
+
+  assert.deepEqual(navigation.revalidatedPaths, [
+    "/projects",
+    `/projects/${project.id}`,
+  ]);
+
+  const restoredProject = await getProjectForUser(project.id, owner.user.id);
+  assert.equal(restoredProject?.archivedAt, null);
+
+  const activeProjects = await listProjectsForUser(owner.user.id, {
+    archived: false,
+  });
+  const archivedProjects = await listProjectsForUser(owner.user.id, {
+    archived: true,
+  });
+
+  assert.equal(activeProjects.length, 1);
+  assert.equal(activeProjects[0]?.id, project.id);
+  assert.equal(archivedProjects.length, 0);
+
+  const activity = await db.activityLog.findMany({
+    where: {
+      projectId: project.id,
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+    select: {
+      eventType: true,
+      summary: true,
+    },
+  });
+
+  assert.equal(activity[0]?.eventType, "project_restored");
+  assert.equal(activity[0]?.summary, "Restored project Garden Suite.");
+});
+
+test("project archive actions ignore projects outside the current workspace", async (t) => {
+  const integration = createIntegrationContext();
+  t.after(async () => {
+    await integration.cleanup();
+  });
+
+  const owner = await integration.createWorkspaceMember();
+  const outsider = await integration.createWorkspaceMember();
+  const project = await integration.createProject({
+    workspaceId: owner.workspace.id,
+    createdById: owner.user.id,
+  });
+  const navigation = createNavigationHarness();
+
+  await archiveProjectActionWithDependencies(
+    {
+      db,
+      requireCurrentUser: async () => outsider.user,
+      getProjectForUser,
+      revalidatePath: navigation.revalidatePath,
+    },
+    project.id,
+  );
+
+  assert.deepEqual(navigation.revalidatedPaths, []);
+
+  const persistedProject = await db.project.findUnique({
+    where: {
+      id: project.id,
+    },
+    select: {
+      archivedAt: true,
+    },
+  });
+
+  assert.equal(persistedProject?.archivedAt, null);
+
+  const activityCount = await db.activityLog.count({
+    where: {
+      projectId: project.id,
+    },
+  });
+
+  assert.equal(activityCount, 0);
+});


### PR DESCRIPTION
## What changed
- added server actions to archive and restore projects using the existing soft-delete `archivedAt` field
- filtered archived projects out of the default projects list and added an archived projects view with restore controls
- added archive and restore affordances on the project overview page
- logged archive and restore activity events and covered the lifecycle with integration-style tests

## Why
Projects already supported soft archiving in the schema, but there was no workflow to use it. That left completed or abandoned work mixed into the active project index and gave users no way to restore archived projects later.

## Impact
- active project lists stay focused on current work
- archived projects remain recoverable without data loss
- project lifecycle changes now appear in activity history

## Validation
- `npm run typecheck`
- `npm test`
